### PR TITLE
Move fsockopen out of constructor

### DIFF
--- a/src/TweeGearmanStat/Queue/Gearman.php
+++ b/src/TweeGearmanStat/Queue/Gearman.php
@@ -51,12 +51,18 @@ class Gearman
         if (empty($this->servers)) {
             return false;
         }
+        $error = '';
+        $errno = 0;
+        $timeout = isset($options[self::OPTION_TIMEOUT]) ? $options[self::OPTION_TIMEOUT] : $this->defaultTimeout;
         foreach ($this->servers as $name => $options) {
-            $error = '';
-            $errno = 0;
-            $timeout = isset($options[self::OPTION_TIMEOUT]) ? $options[self::OPTION_TIMEOUT] : $this->defaultTimeout;
-            $socket  = fsockopen($options[self::OPTION_HOST], $options[self::OPTION_PORT], $error, $errno, $timeout );
-            $this->connections[$name] = $socket;
+            $this->connections[$name] =
+                fsockopen(
+                    $options[self::OPTION_HOST],
+                    $options[self::OPTION_PORT],
+                    $error,
+                    $errno,
+                    $timeout
+                );
         }
 
         return true;


### PR DESCRIPTION
I've made a small change to where the `fsockopen` call is being made.  In testing environments (e.g. Travis) where there is no expectation of having a gearman server to connect to, calling `fsockopen` within the constructor was problematic.  Instead, this has been moved to a `connect()` method that is called before the connections are needed.   Please let me know what you think.  Thanks!
