### PR TITLE
Set read/write timeout.

### DIFF
--- a/src/TweeGearmanStat/Queue/Gearman.php
+++ b/src/TweeGearmanStat/Queue/Gearman.php
@@ -41,6 +41,7 @@ class Gearman
             $errno = 0;
             $timeout = isset($options[self::OPTION_TIMEOUT]) ? $options[self::OPTION_TIMEOUT] : $this->defaultTimeout;
             $socket  = fsockopen($options[self::OPTION_HOST], $options[self::OPTION_PORT], $error, $errno, $timeout );
+            stream_set_timeout($socket, $timeout);
             $this->connections[$name] = $socket;
         }
         return $this->connections;

--- a/src/TweeGearmanStat/Queue/Gearman/Parser.php
+++ b/src/TweeGearmanStat/Queue/Gearman/Parser.php
@@ -14,6 +14,7 @@ class Parser
                 'queue'   => 0,
                 'running' => 0,
                 'workers' => 0,
+                'error'   => true,
             );
         }
 
@@ -24,6 +25,7 @@ class Parser
             'queue'   => $queue,
             'running' => $running,
             'workers' => $workers,
+            'error'   => false,
         );
     }
 }

--- a/tests/TweeGearmanStat/Queue/Gearman/ParserTest.php
+++ b/tests/TweeGearmanStat/Queue/Gearman/ParserTest.php
@@ -9,7 +9,8 @@ class ParserTest extends PHPUnit_Framework_TestCase
             'name' => 'test2',
             'queue' => 1,
             'running' => 3,
-            'workers' => 5), Parser::statusLine("test2\t1\t3\t5\n"));
+            'workers' => 5,
+            'error' => false), Parser::statusLine("test2\t1\t3\t5\n"));
     }
 
     /**
@@ -22,7 +23,8 @@ class ParserTest extends PHPUnit_Framework_TestCase
             'name' => '',
             'queue' => 0,
             'running' => 0,
-            'workers' => 0), Parser::statusLine($inputString));
+            'workers' => 0,
+            'error' => true), Parser::statusLine($inputString));
     }
 
     public function badDataProvider()

--- a/tests/TweeGearmanStat/Queue/GearmanTest.php
+++ b/tests/TweeGearmanStat/Queue/GearmanTest.php
@@ -13,8 +13,8 @@ class GearmanTest extends PHPUnit_Framework_TestCase
         $statuses = $adapter->status();
         $this->assertArrayHasKey('default', $statuses);
         $status = $statuses['default'];
-        $this->assertContains(array('name' => 'test1', 'queue' => 0, 'running' => 0, 'workers' => 1), $status);
-        $this->assertContains(array('name' => 'test2', 'queue' => 0, 'running' => 0, 'workers' => 1), $status);
+        $this->assertContains(array('name' => 'test1', 'queue' => 0, 'running' => 0, 'workers' => 1, 'error' => false), $status);
+        $this->assertContains(array('name' => 'test2', 'queue' => 0, 'running' => 0, 'workers' => 1, 'error' => false), $status);
     }
     
     public function testConnectWithDefaultTimeout()
@@ -25,8 +25,8 @@ class GearmanTest extends PHPUnit_Framework_TestCase
         $statuses = $adapter->status();
         $this->assertArrayHasKey('default', $statuses);
         $status = $statuses['default'];
-        $this->assertContains(array('name' => 'test1', 'queue' => 0, 'running' => 0, 'workers' => 1), $status);
-        $this->assertContains(array('name' => 'test2', 'queue' => 0, 'running' => 0, 'workers' => 1), $status);
+        $this->assertContains(array('name' => 'test1', 'queue' => 0, 'running' => 0, 'workers' => 1, 'error' => false), $status);
+        $this->assertContains(array('name' => 'test2', 'queue' => 0, 'running' => 0, 'workers' => 1, 'error' => false), $status);
     }
 
     /**


### PR DESCRIPTION
Per http://us2.php.net/manual/en/function.fsockopen.php setting the timeout parameter only sets the connection timeout.

> If you need to set a timeout for reading/writing data over the socket, use stream_set_timeout(), as the timeout parameter to fsockopen() only applies while connecting the socket.

Thus, currently there is only a connection timeout.  The problem I am having is Gearmand will open a connection and stall occasionally.  The connection will them timeout 30-40 seconds later. I want this to happen ***sooner***.

I also added a parameter to the response to indicate whether there was an error or not.

I have also updated the tests to reflect the change.