### PR TITLE
Adds constants for parser results.

### DIFF
--- a/src/TweeGearmanStat/Queue/Gearman/Parser.php
+++ b/src/TweeGearmanStat/Queue/Gearman/Parser.php
@@ -3,6 +3,12 @@ namespace TweeGearmanStat\Queue\Gearman;
 
 class Parser
 {
+    const NAME    = 'name';
+    const QUEUE   = 'queue';
+    const RUNNING = 'running';
+    const WORKERS = 'workers';
+    const ERROR   = 'error';
+
     public static function statusLine($line)
     {
         $line = trim($line);
@@ -10,22 +16,22 @@ class Parser
         
         if (count($exploded) != 4) {
             return array(
-                'name'    => '',
-                'queue'   => 0,
-                'running' => 0,
-                'workers' => 0,
-                'error'   => true,
+                self::NAME    => '',
+                self::QUEUE   => 0,
+                self::RUNNING => 0,
+                self::WORKERS => 0,
+                self::ERROR   => true,
             );
         }
 
         list($name, $queue, $running, $workers) = $exploded;
         
         return array(
-            'name'    => $name,
-            'queue'   => $queue,
-            'running' => $running,
-            'workers' => $workers,
-            'error'   => false,
+            self::NAME    => $name,
+            self::QUEUE   => $queue,
+            self::RUNNING => $running,
+            self::WORKERS => $workers,
+            self::ERROR   => false,
         );
     }
 }


### PR DESCRIPTION
I know I personally would much prefer to use predefined constants when checking these keys in my code. I feel like many others would as well.
